### PR TITLE
feat: add health ping monitoring with GitHub-style contribution chart

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,3 +58,6 @@ AUTH_PASSKEY_ENABLED=true
 
 # Retention
 RETENTION_CRON="* * * * *"
+
+# Health Ping (check database connectivity)
+HEALTH_PING_CRON="* * * * *"

--- a/app/(customer)/dashboard/(admin)/health/page.tsx
+++ b/app/(customer)/dashboard/(admin)/health/page.tsx
@@ -1,0 +1,64 @@
+import {PageParams} from "@/types/next";
+import {Page, PageContent, PageDescription, PageHeader, PageTitle} from "@/features/layout/page";
+import {currentUser} from "@/lib/auth/current-user";
+import {notFound} from "next/navigation";
+import {listOrganizations} from "@/lib/auth/auth";
+import {getDatabasesWithHealth, getHealthPingFailures} from "@/db/services/health-ping";
+import {getAllHealthDashboardPreferences} from "@/db/services/health-dashboard-preference";
+import {HealthStatusList} from "@/components/wrappers/dashboard/health/health-status-list";
+import {Metadata} from "next";
+
+export const metadata: Metadata = {
+    title: "Health Status",
+};
+
+export default async function RoutePage(props: PageParams<{}>) {
+    const user = await currentUser();
+    const organizations = await listOrganizations();
+
+    if (!user || !organizations) notFound();
+
+    const organizationIds = organizations.map((org) => org.id);
+    const databases = await getDatabasesWithHealth(organizationIds);
+    const databaseIds = databases.map((db) => db.id);
+
+    const [failedPings, preferences] = await Promise.all([
+        getHealthPingFailures(databaseIds, 90),
+        getAllHealthDashboardPreferences(user.id),
+    ]);
+
+    const prefsMap: Record<string, boolean> = {};
+    for (const pref of preferences) {
+        prefsMap[pref.databaseId] = pref.visible;
+    }
+
+    const serializedDatabases = databases.map((db) => ({
+        id: db.id,
+        name: db.name,
+        dbms: db.dbms,
+        lastContact: db.lastContact,
+    }));
+
+    const serializedFailures = failedPings.map((f) => ({
+        databaseId: f.databaseId,
+        timestamp: f.timestamp,
+    }));
+
+    return (
+        <Page>
+            <PageHeader>
+                <PageTitle>Health Status</PageTitle>
+            </PageHeader>
+            <PageDescription>
+                Monitor database connectivity. Toggle the switch to pin a chart to your main dashboard.
+            </PageDescription>
+            <PageContent>
+                <HealthStatusList
+                    databases={serializedDatabases}
+                    failedPings={serializedFailures}
+                    preferences={prefsMap}
+                />
+            </PageContent>
+        </Page>
+    );
+}

--- a/app/(customer)/dashboard/(admin)/health/page.tsx
+++ b/app/(customer)/dashboard/(admin)/health/page.tsx
@@ -50,7 +50,7 @@ export default async function RoutePage(props: PageParams<{}>) {
                 <PageTitle>Health Status</PageTitle>
             </PageHeader>
             <PageDescription>
-                Monitor database connectivity. Toggle the switch to pin a chart to your main dashboard.
+                Monitor the health of your agents and databases. Toggle the switch to pin a chart to your main dashboard.
             </PageDescription>
             <PageContent>
                 <HealthStatusList

--- a/app/(customer)/dashboard/(admin)/health/page.tsx
+++ b/app/(customer)/dashboard/(admin)/health/page.tsx
@@ -23,7 +23,7 @@ export default async function RoutePage(props: PageParams<{}>) {
     const databaseIds = databases.map((db) => db.id);
 
     const [failedPings, preferences] = await Promise.all([
-        getHealthPingFailures(databaseIds, 90),
+        getHealthPingFailures(databaseIds, 180),
         getAllHealthDashboardPreferences(user.id),
     ]);
 

--- a/app/(customer)/dashboard/home/page.tsx
+++ b/app/(customer)/dashboard/home/page.tsx
@@ -12,6 +12,7 @@ import {Metadata} from "next";
 import {getHealthDashboardPreferences} from "@/db/services/health-dashboard-preference";
 import {getHealthPingFailures} from "@/db/services/health-ping";
 import {HealthPingChart} from "@/components/wrappers/dashboard/health/health-ping-chart";
+import {Badge} from "@/components/ui/badge";
 
 export const metadata: Metadata = {
     title: "Home",
@@ -138,7 +139,10 @@ export default async function RoutePage(props: PageParams<{}>) {
                 </div>
                 {pinnedDatabases.length > 0 && (
                     <div className="flex flex-col gap-4">
-                        <h2 className="text-lg font-semibold">Health Monitoring</h2>
+                        <div className="flex items-center gap-2">
+                            <h2 className="text-lg font-semibold">Health Monitoring</h2>
+                            <Badge variant="secondary" className="text-xs">Agent Health</Badge>
+                        </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                             {pinnedDatabases.map((database) => {
                                 const dbFailures = pinnedFailures

--- a/app/(customer)/dashboard/home/page.tsx
+++ b/app/(customer)/dashboard/home/page.tsx
@@ -61,7 +61,7 @@ export default async function RoutePage(props: PageParams<{}>) {
 
     let pinnedFailures: {databaseId: string; databaseName: string; timestamp: Date}[] = [];
     if (pinnedDbIds.length > 0) {
-        pinnedFailures = await getHealthPingFailures(pinnedDbIds, 90);
+        pinnedFailures = await getHealthPingFailures(pinnedDbIds, 180);
     }
 
     return (

--- a/app/(customer)/dashboard/home/page.tsx
+++ b/app/(customer)/dashboard/home/page.tsx
@@ -9,6 +9,9 @@ import {asc, inArray} from "drizzle-orm";
 import * as drizzleDb from "@/db";
 import {listOrganizations} from "@/lib/auth/auth";
 import {Metadata} from "next";
+import {getHealthDashboardPreferences} from "@/db/services/health-dashboard-preference";
+import {getHealthPingFailures} from "@/db/services/health-ping";
+import {HealthPingChart} from "@/components/wrappers/dashboard/health/health-ping-chart";
 
 export const metadata: Metadata = {
     title: "Home",
@@ -50,6 +53,15 @@ export default async function RoutePage(props: PageParams<{}>) {
 
     const availableBackups = backupsEvolution.filter(backup => backup.deletedAt == null);
 
+    // Health dashboard: fetch pinned databases and their failure data
+    const pinnedPrefs = await getHealthDashboardPreferences(user.id);
+    const pinnedDbIds = pinnedPrefs.map((p) => p.databaseId);
+    const pinnedDatabases = databasesOfAllProjects.filter((db) => pinnedDbIds.includes(db.id));
+
+    let pinnedFailures: {databaseId: string; databaseName: string; timestamp: Date}[] = [];
+    if (pinnedDbIds.length > 0) {
+        pinnedFailures = await getHealthPingFailures(pinnedDbIds, 90);
+    }
 
     return (
         <Page>
@@ -124,6 +136,29 @@ export default async function RoutePage(props: PageParams<{}>) {
                         </CardContent>
                     </Card>
                 </div>
+                {pinnedDatabases.length > 0 && (
+                    <div className="flex flex-col gap-4">
+                        <h2 className="text-lg font-semibold">Health Monitoring</h2>
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            {pinnedDatabases.map((database) => {
+                                const dbFailures = pinnedFailures
+                                    .filter((f) => f.databaseId === database.id)
+                                    .map((f) => ({timestamp: f.timestamp}));
+
+                                return (
+                                    <HealthPingChart
+                                        key={database.id}
+                                        databaseName={database.name}
+                                        databaseId={database.id}
+                                        dbms={database.dbms}
+                                        lastContact={database.lastContact}
+                                        failedPings={dbFailures}
+                                    />
+                                );
+                            })}
+                        </div>
+                    </div>
+                )}
                 {/*Do not delete*/}
                 {/*<div className="flex flex-1 flex-col gap-4">*/}
                 {/*    <div className="grid auto-rows-min gap-4 md:grid-cols-3">*/}

--- a/src/components/wrappers/dashboard/common/sidebar/menu-sidebar-main.tsx
+++ b/src/components/wrappers/dashboard/common/sidebar/menu-sidebar-main.tsx
@@ -7,7 +7,8 @@ import {
     Layers,
     ChartArea,
     ShieldHalf,
-    Building, UserRoundCog, Mail, PackageOpen, Logs, Megaphone, Blocks, Warehouse, BookOpen
+    Building, UserRoundCog, Mail, PackageOpen, Logs, Megaphone, Blocks, Warehouse, BookOpen,
+    HeartPulse
 } from "lucide-react";
 import {SidebarGroupItem, SidebarMenuCustomBase} from "@/components/wrappers/dashboard/common/sidebar/menu-sidebar";
 import {authClient} from "@/lib/auth/auth-client";
@@ -60,6 +61,12 @@ export const SidebarMenuCustomMain = () => {
                     url: "/agents",
                     icon: ShieldHalf,
                     details: true,
+                    type: "item"
+                },
+                {
+                    title: "Health Status",
+                    url: "/health",
+                    icon: HeartPulse,
                     type: "item"
                 },
                 {

--- a/src/components/wrappers/dashboard/database/channels-policy/policy.schema.ts
+++ b/src/components/wrappers/dashboard/database/channels-policy/policy.schema.ts
@@ -3,7 +3,7 @@ import {z} from "zod";
 export const PolicySchema = z.object({
     channelId: z.string().min(1, "Please select channel"),
     eventKinds: z.array(z.enum([
-        'error_backup', 'error_restore', 'success_restore', 'success_backup', 'weekly_report'
+        'error_backup', 'error_restore', 'success_restore', 'success_backup', 'weekly_report', 'health_ping_fail'
     ]))
         .optional(),
     enabled: z.boolean().default(true),
@@ -24,6 +24,7 @@ export const EVENT_KIND_OPTIONS = [
     {label: "Success Restore", value: "success_restore"},
     {label: "Success Backup", value: "success_backup"},
     // {label: "Weekly Report", value: "weekly_report"},
+    {label: "Health Ping Fail", value: "health_ping_fail"},
 ];
 
 export const EVENT_KIND_BACKUP_ONLY_OPTIONS = [

--- a/src/components/wrappers/dashboard/health/health-ping-chart.tsx
+++ b/src/components/wrappers/dashboard/health/health-ping-chart.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import {useMemo} from "react";
+import {cn} from "@/lib/utils";
+import {Tooltip, TooltipContent, TooltipTrigger} from "@/components/ui/tooltip";
+import {Card, CardContent, CardHeader, CardTitle} from "@/components/ui/card";
+import {ConnectionIndicator} from "@/components/wrappers/common/connection-indicator";
+
+export type HealthPingChartProps = {
+    databaseName: string;
+    databaseId: string;
+    dbms: string;
+    lastContact: Date | null;
+    failedPings: {timestamp: Date}[];
+    days?: number;
+};
+
+type CellData = {
+    date: Date;
+    dayLabel: string;
+    failures: number;
+    isFuture: boolean;
+};
+
+function buildGrid(days: number, failedPings: {timestamp: Date}[]): CellData[] {
+    const now = new Date();
+    const cells: CellData[] = [];
+
+    const failuresByDay = new Map<string, number>();
+    for (const ping of failedPings) {
+        const d = new Date(ping.timestamp);
+        const key = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+        failuresByDay.set(key, (failuresByDay.get(key) || 0) + 1);
+    }
+
+    for (let i = days - 1; i >= 0; i--) {
+        const date = new Date(now);
+        date.setDate(date.getDate() - i);
+        date.setHours(0, 0, 0, 0);
+
+        const key = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+        const failures = failuresByDay.get(key) || 0;
+
+        const dayLabel = date.toLocaleDateString(undefined, {
+            weekday: "short",
+            month: "short",
+            day: "numeric",
+        });
+
+        cells.push({
+            date,
+            dayLabel,
+            failures,
+            isFuture: false,
+        });
+    }
+
+    return cells;
+}
+
+function getCellColor(cell: CellData): string {
+    if (cell.isFuture) return "bg-muted";
+    if (cell.failures > 0) {
+        if (cell.failures >= 10) return "bg-red-600";
+        if (cell.failures >= 5) return "bg-red-500";
+        return "bg-red-400";
+    }
+    return "bg-green-500";
+}
+
+export const HealthPingChart = ({
+    databaseName,
+    databaseId,
+    dbms,
+    lastContact,
+    failedPings,
+    days = 90,
+}: HealthPingChartProps) => {
+    const cells = useMemo(() => buildGrid(days, failedPings), [days, failedPings]);
+
+    const weeks: CellData[][] = useMemo(() => {
+        const result: CellData[][] = [];
+        for (let i = 0; i < cells.length; i += 7) {
+            result.push(cells.slice(i, i + 7));
+        }
+        return result;
+    }, [cells]);
+
+    const totalFailures = failedPings.length;
+    const healthyDays = cells.filter((c) => c.failures === 0 && !c.isFuture).length;
+
+    return (
+        <Card className="w-full">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <div className="flex items-center gap-3">
+                    <ConnectionIndicator date={lastContact}/>
+                    <div>
+                        <CardTitle className="text-sm font-medium">{databaseName}</CardTitle>
+                        <p className="text-xs text-muted-foreground uppercase">{dbms}</p>
+                    </div>
+                </div>
+                <div className="text-right">
+                    <p className="text-xs text-muted-foreground">
+                        {healthyDays}/{days} healthy days
+                    </p>
+                    {totalFailures > 0 && (
+                        <p className="text-xs text-red-500">{totalFailures} failure(s)</p>
+                    )}
+                </div>
+            </CardHeader>
+            <CardContent>
+                <div className="flex gap-0.5 overflow-x-auto pb-2">
+                    {weeks.map((week, weekIdx) => (
+                        <div key={weekIdx} className="flex flex-col gap-0.5">
+                            {week.map((cell, dayIdx) => (
+                                <Tooltip key={`${weekIdx}-${dayIdx}`}>
+                                    <TooltipTrigger asChild>
+                                        <div
+                                            className={cn(
+                                                "w-3 h-3 rounded-sm cursor-default transition-colors",
+                                                getCellColor(cell)
+                                            )}
+                                        />
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                        <p className="font-medium">{cell.dayLabel}</p>
+                                        <p>
+                                            {cell.failures === 0
+                                                ? "Healthy"
+                                                : `${cell.failures} failure(s)`}
+                                        </p>
+                                    </TooltipContent>
+                                </Tooltip>
+                            ))}
+                        </div>
+                    ))}
+                </div>
+                <div className="flex items-center gap-2 mt-2 text-xs text-muted-foreground">
+                    <span>Less</span>
+                    <div className="flex gap-0.5">
+                        <div className="w-3 h-3 rounded-sm bg-green-500"/>
+                        <div className="w-3 h-3 rounded-sm bg-red-400"/>
+                        <div className="w-3 h-3 rounded-sm bg-red-500"/>
+                        <div className="w-3 h-3 rounded-sm bg-red-600"/>
+                    </div>
+                    <span>More failures</span>
+                </div>
+            </CardContent>
+        </Card>
+    );
+};

--- a/src/components/wrappers/dashboard/health/health-ping-chart.tsx
+++ b/src/components/wrappers/dashboard/health/health-ping-chart.tsx
@@ -20,10 +20,12 @@ type CellData = {
     dayLabel: string;
     failures: number;
     isFuture: boolean;
+    isToday: boolean;
 };
 
-function buildGrid(days: number, failedPings: {timestamp: Date}[]): CellData[] {
+function buildGrid(pastDays: number, futureDays: number, failedPings: {timestamp: Date}[]): CellData[] {
     const now = new Date();
+    now.setHours(0, 0, 0, 0);
     const cells: CellData[] = [];
 
     const failuresByDay = new Map<string, number>();
@@ -33,13 +35,14 @@ function buildGrid(days: number, failedPings: {timestamp: Date}[]): CellData[] {
         failuresByDay.set(key, (failuresByDay.get(key) || 0) + 1);
     }
 
-    for (let i = days - 1; i >= 0; i--) {
+    for (let i = pastDays; i >= -futureDays; i--) {
         const date = new Date(now);
         date.setDate(date.getDate() - i);
-        date.setHours(0, 0, 0, 0);
 
         const key = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
-        const failures = failuresByDay.get(key) || 0;
+        const isToday = i === 0;
+        const isFuture = i < 0;
+        const failures = isFuture ? 0 : (failuresByDay.get(key) || 0);
 
         const dayLabel = date.toLocaleDateString(undefined, {
             weekday: "short",
@@ -47,12 +50,7 @@ function buildGrid(days: number, failedPings: {timestamp: Date}[]): CellData[] {
             day: "numeric",
         });
 
-        cells.push({
-            date,
-            dayLabel,
-            failures,
-            isFuture: false,
-        });
+        cells.push({date, dayLabel, failures, isFuture, isToday});
     }
 
     return cells;
@@ -76,18 +74,23 @@ export const HealthPingChart = ({
     failedPings,
     days = 90,
 }: HealthPingChartProps) => {
-    const cells = useMemo(() => buildGrid(days, failedPings), [days, failedPings]);
+    const cells = useMemo(() => buildGrid(days, days, failedPings), [days, failedPings]);
 
-    const weeks: CellData[][] = useMemo(() => {
-        const result: CellData[][] = [];
+    const weeks: (CellData | null)[][] = useMemo(() => {
+        const result: (CellData | null)[][] = [];
         for (let i = 0; i < cells.length; i += 7) {
-            result.push(cells.slice(i, i + 7));
+            const week: (CellData | null)[] = cells.slice(i, i + 7);
+            while (week.length < 7) {
+                week.push(null);
+            }
+            result.push(week);
         }
         return result;
     }, [cells]);
 
+    const pastCells = cells.filter((c) => !c.isFuture);
     const totalFailures = failedPings.length;
-    const healthyDays = cells.filter((c) => c.failures === 0 && !c.isFuture).length;
+    const healthyDays = pastCells.filter((c) => c.failures === 0).length;
 
     return (
         <Card className="w-full">
@@ -101,7 +104,7 @@ export const HealthPingChart = ({
                 </div>
                 <div className="text-right">
                     <p className="text-xs text-muted-foreground">
-                        {healthyDays}/{days} healthy days
+                        {healthyDays}/{pastCells.length} healthy days
                     </p>
                     {totalFailures > 0 && (
                         <p className="text-xs text-red-500">{totalFailures} failure(s)</p>
@@ -113,24 +116,45 @@ export const HealthPingChart = ({
                     {weeks.map((week, weekIdx) => (
                         <div key={weekIdx} className="flex flex-col gap-0.5">
                             {week.map((cell, dayIdx) => (
-                                <Tooltip key={`${weekIdx}-${dayIdx}`}>
-                                    <TooltipTrigger asChild>
-                                        <div
-                                            className={cn(
-                                                "w-3 h-3 rounded-sm cursor-default transition-colors",
-                                                getCellColor(cell)
-                                            )}
-                                        />
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                        <p className="font-medium">{cell.dayLabel}</p>
-                                        <p>
-                                            {cell.failures === 0
-                                                ? "Healthy"
-                                                : `${cell.failures} failure(s)`}
-                                        </p>
-                                    </TooltipContent>
-                                </Tooltip>
+                                cell === null ? (
+                                    <div
+                                        key={`${weekIdx}-${dayIdx}`}
+                                        className="w-3 h-3 rounded-full bg-muted"
+                                    />
+                                ) : cell.isFuture ? (
+                                    <Tooltip key={`${weekIdx}-${dayIdx}`}>
+                                        <TooltipTrigger asChild>
+                                            <div className="w-3 h-3 rounded-full bg-muted cursor-default"/>
+                                        </TooltipTrigger>
+                                        <TooltipContent>
+                                            <p className="font-medium">{cell.dayLabel}</p>
+                                            <p>Forecast</p>
+                                        </TooltipContent>
+                                    </Tooltip>
+                                ) : (
+                                    <Tooltip key={`${weekIdx}-${dayIdx}`}>
+                                        <TooltipTrigger asChild>
+                                            <div
+                                                className={cn(
+                                                    "w-3 h-3 rounded-full cursor-default transition-colors",
+                                                    getCellColor(cell),
+                                                    cell.isToday && "ring-2 ring-foreground/50"
+                                                )}
+                                            />
+                                        </TooltipTrigger>
+                                        <TooltipContent>
+                                            <p className="font-medium">
+                                                {cell.dayLabel}
+                                                {cell.isToday && " (Today)"}
+                                            </p>
+                                            <p>
+                                                {cell.failures === 0
+                                                    ? "Healthy"
+                                                    : `${cell.failures} failure(s)`}
+                                            </p>
+                                        </TooltipContent>
+                                    </Tooltip>
+                                )
                             ))}
                         </div>
                     ))}
@@ -138,12 +162,15 @@ export const HealthPingChart = ({
                 <div className="flex items-center gap-2 mt-2 text-xs text-muted-foreground">
                     <span>Less</span>
                     <div className="flex gap-0.5">
-                        <div className="w-3 h-3 rounded-sm bg-green-500"/>
-                        <div className="w-3 h-3 rounded-sm bg-red-400"/>
-                        <div className="w-3 h-3 rounded-sm bg-red-500"/>
-                        <div className="w-3 h-3 rounded-sm bg-red-600"/>
+                        <div className="w-3 h-3 rounded-full bg-green-500"/>
+                        <div className="w-3 h-3 rounded-full bg-red-400"/>
+                        <div className="w-3 h-3 rounded-full bg-red-500"/>
+                        <div className="w-3 h-3 rounded-full bg-red-600"/>
                     </div>
-                    <span>More failures</span>
+                    <span>More</span>
+                    <span className="ml-2">|</span>
+                    <div className="w-3 h-3 rounded-full bg-muted"/>
+                    <span>Forecast</span>
                 </div>
             </CardContent>
         </Card>

--- a/src/components/wrappers/dashboard/health/health-status-list.tsx
+++ b/src/components/wrappers/dashboard/health/health-status-list.tsx
@@ -6,6 +6,8 @@ import {useState} from "react";
 import {Switch} from "@/components/ui/switch";
 import {HealthPingChart} from "./health-ping-chart";
 import {toggleHealthDashboardAction} from "./health.action";
+import {Tabs, TabsContent, TabsList, TabsTrigger} from "@/components/ui/tabs";
+import {Database, Workflow} from "lucide-react";
 
 type DatabaseHealth = {
     id: string;
@@ -46,45 +48,66 @@ export const HealthStatusList = ({
         execute({databaseId, visible});
     };
 
-    if (databases.length === 0) {
-        return (
-            <div className="text-center text-muted-foreground py-12">
-                <p>No databases found. Connect an agent and create a project with a database to start monitoring health.</p>
-            </div>
-        );
-    }
-
     return (
-        <div className="flex flex-col gap-4">
-            {databases.map((database) => {
-                const dbFailures = failedPings
-                    .filter((f) => f.databaseId === database.id)
-                    .map((f) => ({timestamp: new Date(f.timestamp)}));
-
-                return (
-                    <div key={database.id} className="flex flex-col gap-2">
-                        <div className="flex items-center justify-between">
-                            <div/>
-                            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                                <span>Pin to dashboard</span>
-                                <Switch
-                                    checked={localPrefs[database.id] ?? false}
-                                    onCheckedChange={(checked) =>
-                                        handleToggle(database.id, checked)
-                                    }
-                                />
-                            </div>
-                        </div>
-                        <HealthPingChart
-                            databaseName={database.name}
-                            databaseId={database.id}
-                            dbms={database.dbms}
-                            lastContact={database.lastContact}
-                            failedPings={dbFailures}
-                        />
+        <Tabs defaultValue="agent">
+            <TabsList>
+                <TabsTrigger value="agent">
+                    <Workflow className="size-4"/>
+                    Agent
+                </TabsTrigger>
+                <TabsTrigger value="database">
+                    <Database className="size-4"/>
+                    Database
+                </TabsTrigger>
+            </TabsList>
+            <TabsContent value="agent">
+                {databases.length === 0 ? (
+                    <div className="text-center text-muted-foreground py-12">
+                        <p>No databases found. Connect an agent and create a project with a database to start monitoring health.</p>
                     </div>
-                );
-            })}
-        </div>
+                ) : (
+                    <div className="flex flex-col gap-4">
+                        {databases.map((database) => {
+                            const dbFailures = failedPings
+                                .filter((f) => f.databaseId === database.id)
+                                .map((f) => ({timestamp: new Date(f.timestamp)}));
+
+                            return (
+                                <div key={database.id} className="flex flex-col gap-2">
+                                    <div className="flex items-center justify-between">
+                                        <div/>
+                                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                            <span>Pin to dashboard</span>
+                                            <Switch
+                                                checked={localPrefs[database.id] ?? false}
+                                                onCheckedChange={(checked) =>
+                                                    handleToggle(database.id, checked)
+                                                }
+                                            />
+                                        </div>
+                                    </div>
+                                    <HealthPingChart
+                                        databaseName={database.name}
+                                        databaseId={database.id}
+                                        dbms={database.dbms}
+                                        lastContact={database.lastContact}
+                                        failedPings={dbFailures}
+                                    />
+                                </div>
+                            );
+                        })}
+                    </div>
+                )}
+            </TabsContent>
+            <TabsContent value="database">
+                <div className="flex flex-col items-center justify-center py-16 text-center">
+                    <Database className="size-12 text-muted-foreground/50 mb-4"/>
+                    <h3 className="text-lg font-semibold mb-1">Coming Soon</h3>
+                    <p className="text-sm text-muted-foreground max-w-md">
+                        Direct database connectivity monitoring is on the way. This will allow you to monitor your database health independently from agent status.
+                    </p>
+                </div>
+            </TabsContent>
+        </Tabs>
     );
 };

--- a/src/components/wrappers/dashboard/health/health-status-list.tsx
+++ b/src/components/wrappers/dashboard/health/health-status-list.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import {useAction} from "next-safe-action/hooks";
+import {toast} from "sonner";
+import {useState} from "react";
+import {Switch} from "@/components/ui/switch";
+import {HealthPingChart} from "./health-ping-chart";
+import {toggleHealthDashboardAction} from "./health.action";
+
+type DatabaseHealth = {
+    id: string;
+    name: string;
+    dbms: string;
+    lastContact: Date | null;
+};
+
+type HealthStatusListProps = {
+    databases: DatabaseHealth[];
+    failedPings: {databaseId: string; timestamp: Date}[];
+    preferences: Record<string, boolean>;
+};
+
+export const HealthStatusList = ({
+    databases,
+    failedPings,
+    preferences,
+}: HealthStatusListProps) => {
+    const [localPrefs, setLocalPrefs] = useState(preferences);
+
+    const {execute} = useAction(toggleHealthDashboardAction, {
+        onSuccess: ({data}) => {
+            if (data?.success && data.actionSuccess) {
+                toast.success(data.actionSuccess.message);
+            }
+            if (data && !data.success && data.actionError) {
+                toast.error(data.actionError.message);
+            }
+        },
+        onError: () => {
+            toast.error("Failed to update preference");
+        },
+    });
+
+    const handleToggle = (databaseId: string, visible: boolean) => {
+        setLocalPrefs((prev) => ({...prev, [databaseId]: visible}));
+        execute({databaseId, visible});
+    };
+
+    if (databases.length === 0) {
+        return (
+            <div className="text-center text-muted-foreground py-12">
+                <p>No databases found. Connect an agent and create a project with a database to start monitoring health.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-col gap-4">
+            {databases.map((database) => {
+                const dbFailures = failedPings
+                    .filter((f) => f.databaseId === database.id)
+                    .map((f) => ({timestamp: new Date(f.timestamp)}));
+
+                return (
+                    <div key={database.id} className="flex flex-col gap-2">
+                        <div className="flex items-center justify-between">
+                            <div/>
+                            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                <span>Pin to dashboard</span>
+                                <Switch
+                                    checked={localPrefs[database.id] ?? false}
+                                    onCheckedChange={(checked) =>
+                                        handleToggle(database.id, checked)
+                                    }
+                                />
+                            </div>
+                        </div>
+                        <HealthPingChart
+                            databaseName={database.name}
+                            databaseId={database.id}
+                            dbms={database.dbms}
+                            lastContact={database.lastContact}
+                            failedPings={dbFailures}
+                        />
+                    </div>
+                );
+            })}
+        </div>
+    );
+};

--- a/src/components/wrappers/dashboard/health/health.action.ts
+++ b/src/components/wrappers/dashboard/health/health.action.ts
@@ -1,0 +1,38 @@
+"use server";
+
+import {userAction} from "@/lib/safe-actions/actions";
+import {ToggleHealthDashboardSchema} from "./health.schema";
+import {ServerActionResult} from "@/types/action-type";
+import {toggleHealthDashboardPreference} from "@/db/services/health-dashboard-preference";
+import {HealthDashboardPreference} from "@/db/schema/15_health-dashboard-preference";
+
+export const toggleHealthDashboardAction = userAction
+    .schema(ToggleHealthDashboardSchema)
+    .action(async ({parsedInput, ctx}): Promise<ServerActionResult<HealthDashboardPreference>> => {
+        try {
+            const preference = await toggleHealthDashboardPreference(
+                ctx.user.id,
+                parsedInput.databaseId,
+                parsedInput.visible
+            );
+
+            return {
+                success: true,
+                value: preference,
+                actionSuccess: {
+                    message: parsedInput.visible
+                        ? "Health chart pinned to dashboard"
+                        : "Health chart removed from dashboard",
+                },
+            };
+        } catch (error) {
+            return {
+                success: false,
+                actionError: {
+                    message: "Failed to update dashboard preference.",
+                    status: 500,
+                    cause: error instanceof Error ? error.message : "Unknown error",
+                },
+            };
+        }
+    });

--- a/src/components/wrappers/dashboard/health/health.schema.ts
+++ b/src/components/wrappers/dashboard/health/health.schema.ts
@@ -1,0 +1,8 @@
+import {z} from "zod";
+
+export const ToggleHealthDashboardSchema = z.object({
+    databaseId: z.string().min(1),
+    visible: z.boolean(),
+});
+
+export type ToggleHealthDashboardType = z.infer<typeof ToggleHealthDashboardSchema>;

--- a/src/components/wrappers/dashboard/projects/database/database-content.tsx
+++ b/src/components/wrappers/dashboard/projects/database/database-content.tsx
@@ -17,9 +17,12 @@ import { capitalizeFirstLetter } from "@/utils/text";
 import { RetentionPolicySheet } from "@/components/wrappers/dashboard/database/retention-policy/retention-policy-sheet";
 import { CronButton } from "@/components/wrappers/dashboard/database/cron-button/cron-button";
 import { ChannelPoliciesModal } from "@/components/wrappers/dashboard/database/channels-policy/policy-modal";
-import { HardDrive, Megaphone } from "lucide-react";
+import { HardDrive, HeartPulse, Megaphone } from "lucide-react";
 import { ImportModal } from "@/components/wrappers/dashboard/database/import/import-modal";
 import { BackupButton } from "@/components/wrappers/dashboard/backup/backup-button/backup-button";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 export type DatabaseContentProps = {
   settings: Setting;
@@ -118,6 +121,16 @@ export const DatabaseContent = (props: DatabaseContentProps) => {
                   organizationId={props.organizationId}
                 />
                 <ImportModal database={database} />
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button variant="outline" asChild>
+                      <Link href="/dashboard/health">
+                        <HeartPulse />
+                      </Link>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Health Status</TooltipContent>
+                </Tooltip>
               </div>
               <div className="flex items-center gap-2">
                 <BackupButton

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -15,6 +15,7 @@ import * as notificationLog from "./schema/11_notification-log";
 import * as storageChannel from "./schema/12_storage-channel";
 import * as storagePolicy from "@/db/schema/13_storage-policy";
 import * as backupStorage from "@/db/schema/14_storage-backup";
+import * as healthDashboardPreference from "@/db/schema/15_health-dashboard-preference";
 
 
 import {Pool} from "pg";
@@ -46,7 +47,8 @@ export const schemas = {
     ...notificationLog,
     ...storageChannel,
     ...storagePolicy,
-    ...backupStorage
+    ...backupStorage,
+    ...healthDashboardPreference
 };
 
 export const db = drizzle({

--- a/src/db/migrations/0040_rich_eternity.sql
+++ b/src/db/migrations/0040_rich_eternity.sql
@@ -1,0 +1,13 @@
+ALTER TYPE "public"."event_kind" ADD VALUE 'health_ping_fail';--> statement-breakpoint
+CREATE TABLE "health_dashboard_preference" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"database_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"visible" boolean DEFAULT false NOT NULL,
+	"updated_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"deleted_at" timestamp
+);
+--> statement-breakpoint
+ALTER TABLE "health_dashboard_preference" ADD CONSTRAINT "health_dashboard_preference_database_id_databases_id_fk" FOREIGN KEY ("database_id") REFERENCES "public"."databases"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "health_dashboard_preference" ADD CONSTRAINT "health_dashboard_preference_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/src/db/migrations/meta/0040_snapshot.json
+++ b/src/db/migrations/meta/0040_snapshot.json
@@ -1,0 +1,2518 @@
+{
+  "id": "80a069d9-87b9-4d89-8bf1-ebd51800257e",
+  "prevId": "c1175913-c1dd-43a4-b396-282406986d5e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "smtp_password": {
+          "name": "smtp_password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtp_from": {
+          "name": "smtp_from",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtp_host": {
+          "name": "smtp_host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtp_port": {
+          "name": "smtp_port",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtp_user": {
+          "name": "smtp_user",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtp_secure": {
+          "name": "smtp_secure",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_storage_channel_id": {
+          "name": "default_storage_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryption": {
+          "name": "encryption",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_default_storage_channel_id_storage_channel_id_fk": {
+          "name": "settings_default_storage_channel_id_storage_channel_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "storage_channel",
+          "columnsFrom": [
+            "default_storage_channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_name_unique": {
+          "name": "settings_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backedUp": {
+          "name": "backedUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_provider_provider_id_unique": {
+          "name": "sso_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.two_factor": {
+      "name": "two_factor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "user_themes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'light'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastConnectedAt": {
+          "name": "lastConnectedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastChangedPasswordAt": {
+          "name": "lastChangedPasswordAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_organization_id_organization_id_fk": {
+          "name": "projects_organization_id_organization_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.backups": {
+      "name": "backups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "status": {
+          "name": "status",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "database_id": {
+          "name": "database_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported": {
+          "name": "imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "backups_database_id_databases_id_fk": {
+          "name": "backups_database_id_databases_id_fk",
+          "tableFrom": "backups",
+          "tableTo": "databases",
+          "columnsFrom": [
+            "database_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.databases": {
+      "name": "databases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_database_id": {
+          "name": "agent_database_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dbms": {
+          "name": "dbms",
+          "type": "dbms_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backup_policy": {
+          "name": "backup_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_waiting_for_backup": {
+          "name": "is_waiting_for_backup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backup_to_restore": {
+          "name": "backup_to_restore",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_contact": {
+          "name": "last_contact",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "databases_agent_id_agents_id_fk": {
+          "name": "databases_agent_id_agents_id_fk",
+          "tableFrom": "databases",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "databases_project_id_projects_id_fk": {
+          "name": "databases_project_id_projects_id_fk",
+          "tableFrom": "databases",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restorations": {
+      "name": "restorations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "status": {
+          "name": "status",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "backup_storage_id": {
+          "name": "backup_storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backup_id": {
+          "name": "backup_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "database_id": {
+          "name": "database_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "restorations_backup_storage_id_backup_storage_id_fk": {
+          "name": "restorations_backup_storage_id_backup_storage_id_fk",
+          "tableFrom": "restorations",
+          "tableTo": "backup_storage",
+          "columnsFrom": [
+            "backup_storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "restorations_backup_id_backups_id_fk": {
+          "name": "restorations_backup_id_backups_id_fk",
+          "tableFrom": "restorations",
+          "tableTo": "backups",
+          "columnsFrom": [
+            "backup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "restorations_database_id_databases_id_fk": {
+          "name": "restorations_database_id_databases_id_fk",
+          "tableFrom": "restorations",
+          "tableTo": "databases",
+          "columnsFrom": [
+            "database_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_policies": {
+      "name": "retention_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "database_id": {
+          "name": "database_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "retention_policy_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 7
+        },
+        "days": {
+          "name": "days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "gfs_daily": {
+          "name": "gfs_daily",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 7
+        },
+        "gfs_weekly": {
+          "name": "gfs_weekly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 4
+        },
+        "gfs_monthly": {
+          "name": "gfs_monthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 12
+        },
+        "gfs_yearly": {
+          "name": "gfs_yearly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 3
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "retention_policies_database_id_databases_id_fk": {
+          "name": "retention_policies_database_id_databases_id_fk",
+          "tableFrom": "retention_policies",
+          "tableTo": "databases",
+          "columnsFrom": [
+            "database_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "last_contact": {
+          "name": "last_contact",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_slug_unique": {
+          "name": "agents_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_channel": {
+      "name": "notification_channel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_channel_organization_id_organization_id_fk": {
+          "name": "notification_channel_organization_id_organization_id_fk",
+          "tableFrom": "notification_channel",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_notification_channels": {
+      "name": "organization_notification_channels",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_channel_id": {
+          "name": "notification_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_notification_channels_organization_id_organization_id_fk": {
+          "name": "organization_notification_channels_organization_id_organization_id_fk",
+          "tableFrom": "organization_notification_channels",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_notification_channels_notification_channel_id_notification_channel_id_fk": {
+          "name": "organization_notification_channels_notification_channel_id_notification_channel_id_fk",
+          "tableFrom": "organization_notification_channels",
+          "tableTo": "notification_channel",
+          "columnsFrom": [
+            "notification_channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_notification_channels_organization_id_notification_channel_id_unique": {
+          "name": "organization_notification_channels_organization_id_notification_channel_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "notification_channel_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_policy": {
+      "name": "alert_policy",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "notification_channel_id": {
+          "name": "notification_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_kind": {
+          "name": "event_kind",
+          "type": "event_kind[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "database_id": {
+          "name": "database_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alert_policy_notification_channel_id_notification_channel_id_fk": {
+          "name": "alert_policy_notification_channel_id_notification_channel_id_fk",
+          "tableFrom": "alert_policy",
+          "tableTo": "notification_channel",
+          "columnsFrom": [
+            "notification_channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_policy_database_id_databases_id_fk": {
+          "name": "alert_policy_database_id_databases_id_fk",
+          "tableFrom": "alert_policy",
+          "tableTo": "databases",
+          "columnsFrom": [
+            "database_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_response": {
+          "name": "provider_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_storage_channels": {
+      "name": "organization_storage_channels",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_channel_id": {
+          "name": "storage_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_storage_channels_organization_id_organization_id_fk": {
+          "name": "organization_storage_channels_organization_id_organization_id_fk",
+          "tableFrom": "organization_storage_channels",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_storage_channels_storage_channel_id_storage_channel_id_fk": {
+          "name": "organization_storage_channels_storage_channel_id_storage_channel_id_fk",
+          "tableFrom": "organization_storage_channels",
+          "tableTo": "storage_channel",
+          "columnsFrom": [
+            "storage_channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_storage_channels_organization_id_storage_channel_id_unique": {
+          "name": "organization_storage_channels_organization_id_storage_channel_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "storage_channel_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_channel": {
+      "name": "storage_channel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "provider_storage_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_channel_organization_id_organization_id_fk": {
+          "name": "storage_channel_organization_id_organization_id_fk",
+          "tableFrom": "storage_channel",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_policy": {
+      "name": "storage_policy",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "storage_channel_id": {
+          "name": "storage_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "database_id": {
+          "name": "database_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_policy_storage_channel_id_storage_channel_id_fk": {
+          "name": "storage_policy_storage_channel_id_storage_channel_id_fk",
+          "tableFrom": "storage_policy",
+          "tableTo": "storage_channel",
+          "columnsFrom": [
+            "storage_channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storage_policy_database_id_databases_id_fk": {
+          "name": "storage_policy_database_id_databases_id_fk",
+          "tableFrom": "storage_policy",
+          "tableTo": "databases",
+          "columnsFrom": [
+            "database_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.backup_storage": {
+      "name": "backup_storage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "backup_id": {
+          "name": "backup_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_channel_id": {
+          "name": "storage_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "backup_storage_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "backup_storage_backup_id_backups_id_fk": {
+          "name": "backup_storage_backup_id_backups_id_fk",
+          "tableFrom": "backup_storage",
+          "tableTo": "backups",
+          "columnsFrom": [
+            "backup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "backup_storage_storage_channel_id_storage_channel_id_fk": {
+          "name": "backup_storage_storage_channel_id_storage_channel_id_fk",
+          "tableFrom": "backup_storage",
+          "tableTo": "storage_channel",
+          "columnsFrom": [
+            "storage_channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_dashboard_preference": {
+      "name": "health_dashboard_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "database_id": {
+          "name": "database_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visible": {
+          "name": "visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "health_dashboard_preference_database_id_databases_id_fk": {
+          "name": "health_dashboard_preference_database_id_databases_id_fk",
+          "tableFrom": "health_dashboard_preference",
+          "tableTo": "databases",
+          "columnsFrom": [
+            "database_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "health_dashboard_preference_user_id_user_id_fk": {
+          "name": "health_dashboard_preference_user_id_user_id_fk",
+          "tableFrom": "health_dashboard_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_themes": {
+      "name": "user_themes",
+      "schema": "public",
+      "values": [
+        "light",
+        "dark",
+        "system"
+      ]
+    },
+    "public.retention_policy_type": {
+      "name": "retention_policy_type",
+      "schema": "public",
+      "values": [
+        "count",
+        "days",
+        "gfs"
+      ]
+    },
+    "public.provider_kind": {
+      "name": "provider_kind",
+      "schema": "public",
+      "values": [
+        "slack",
+        "smtp",
+        "discord",
+        "telegram",
+        "gotify",
+        "ntfy",
+        "webhook"
+      ]
+    },
+    "public.event_kind": {
+      "name": "event_kind",
+      "schema": "public",
+      "values": [
+        "error_backup",
+        "error_restore",
+        "success_restore",
+        "success_backup",
+        "weekly_report",
+        "health_ping_fail"
+      ]
+    },
+    "public.level": {
+      "name": "level",
+      "schema": "public",
+      "values": [
+        "critical",
+        "warning",
+        "info"
+      ]
+    },
+    "public.provider_storage_kind": {
+      "name": "provider_storage_kind",
+      "schema": "public",
+      "values": [
+        "local",
+        "s3",
+        "google-drive"
+      ]
+    },
+    "public.backup_storage_status": {
+      "name": "backup_storage_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "success",
+        "failed"
+      ]
+    },
+    "public.dbms_status": {
+      "name": "dbms_status",
+      "schema": "public",
+      "values": [
+        "postgresql",
+        "mysql",
+        "mongodb",
+        "sqlite",
+        "redis",
+        "valkey"
+      ]
+    },
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": [
+        "waiting",
+        "ongoing",
+        "failed",
+        "success"
+      ]
+    },
+    "public.type_storage": {
+      "name": "type_storage",
+      "schema": "public",
+      "values": [
+        "local",
+        "s3"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1773659096498,
       "tag": "0039_conscious_solo",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1774050726760,
+      "tag": "0040_rich_eternity",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/10_alert-policy.ts
+++ b/src/db/schema/10_alert-policy.ts
@@ -6,7 +6,7 @@ import {database} from "@/db/schema/07_database";
 import {createSelectSchema} from "drizzle-zod";
 import {z} from "zod";
 
-export const eventKindEnum = pgEnum('event_kind', ['error_backup', 'error_restore', 'success_restore', 'success_backup', 'weekly_report']);
+export const eventKindEnum = pgEnum('event_kind', ['error_backup', 'error_restore', 'success_restore', 'success_backup', 'weekly_report', 'health_ping_fail']);
 
 export const alertPolicy = pgTable('alert_policy', {
     id: uuid('id').defaultRandom().primaryKey(),

--- a/src/db/schema/15_health-dashboard-preference.ts
+++ b/src/db/schema/15_health-dashboard-preference.ts
@@ -1,0 +1,33 @@
+import {boolean, pgTable, uuid} from "drizzle-orm/pg-core";
+import {timestamps} from "@/db/schema/00_common";
+import {database} from "@/db/schema/07_database";
+import {user} from "@/db/schema/02_user";
+import {relations} from "drizzle-orm";
+import {createSelectSchema} from "drizzle-zod";
+import {z} from "zod";
+
+export const healthDashboardPreference = pgTable('health_dashboard_preference', {
+    id: uuid('id').defaultRandom().primaryKey(),
+    databaseId: uuid('database_id')
+        .notNull()
+        .references(() => database.id, {onDelete: 'cascade'}),
+    userId: uuid('user_id')
+        .notNull()
+        .references(() => user.id, {onDelete: 'cascade'}),
+    visible: boolean('visible').default(false).notNull(),
+    ...timestamps,
+});
+
+export const healthDashboardPreferenceRelations = relations(healthDashboardPreference, ({one}) => ({
+    database: one(database, {
+        fields: [healthDashboardPreference.databaseId],
+        references: [database.id],
+    }),
+    user: one(user, {
+        fields: [healthDashboardPreference.userId],
+        references: [user.id],
+    }),
+}));
+
+export const healthDashboardPreferenceSchema = createSelectSchema(healthDashboardPreference);
+export type HealthDashboardPreference = z.infer<typeof healthDashboardPreferenceSchema>;

--- a/src/db/services/health-dashboard-preference.ts
+++ b/src/db/services/health-dashboard-preference.ts
@@ -1,0 +1,47 @@
+import {and, eq} from "drizzle-orm";
+import {db} from "@/db";
+import * as drizzleDb from "@/db";
+import {withUpdatedAt} from "@/db/utils";
+
+export async function getHealthDashboardPreferences(userId: string) {
+    return db.query.healthDashboardPreference.findMany({
+        where: and(
+            eq(drizzleDb.schemas.healthDashboardPreference.userId, userId),
+            eq(drizzleDb.schemas.healthDashboardPreference.visible, true)
+        ),
+    });
+}
+
+export async function getAllHealthDashboardPreferences(userId: string) {
+    return db.query.healthDashboardPreference.findMany({
+        where: eq(drizzleDb.schemas.healthDashboardPreference.userId, userId),
+    });
+}
+
+export async function toggleHealthDashboardPreference(
+    userId: string,
+    databaseId: string,
+    visible: boolean
+) {
+    const existing = await db.query.healthDashboardPreference.findFirst({
+        where: and(
+            eq(drizzleDb.schemas.healthDashboardPreference.userId, userId),
+            eq(drizzleDb.schemas.healthDashboardPreference.databaseId, databaseId)
+        ),
+    });
+
+    if (existing) {
+        const [updated] = await db
+            .update(drizzleDb.schemas.healthDashboardPreference)
+            .set(withUpdatedAt({visible}))
+            .where(eq(drizzleDb.schemas.healthDashboardPreference.id, existing.id))
+            .returning();
+        return updated;
+    }
+
+    const [created] = await db
+        .insert(drizzleDb.schemas.healthDashboardPreference)
+        .values({userId, databaseId, visible})
+        .returning();
+    return created;
+}

--- a/src/db/services/health-ping.ts
+++ b/src/db/services/health-ping.ts
@@ -28,6 +28,7 @@ export async function getHealthPingFailures(
         .where(
             and(
                 eq(notificationLog.event, "health_ping_fail"),
+                eq(notificationLog.channelId, "00000000-0000-0000-0000-000000000000"),
                 gte(notificationLog.sentAt, since)
             )
         )

--- a/src/db/services/health-ping.ts
+++ b/src/db/services/health-ping.ts
@@ -1,0 +1,70 @@
+import {and, desc, eq, gte, inArray, sql} from "drizzle-orm";
+import {db} from "@/db";
+import * as drizzleDb from "@/db";
+import {notificationLog} from "@/db/schema/11_notification-log";
+
+export type HealthPingFailure = {
+    databaseId: string;
+    databaseName: string;
+    timestamp: Date;
+};
+
+export async function getHealthPingFailures(
+    databaseIds: string[],
+    days: number = 90
+): Promise<HealthPingFailure[]> {
+    if (databaseIds.length === 0) return [];
+
+    const since = new Date();
+    since.setDate(since.getDate() - days);
+
+    const rows = await db
+        .select({
+            payload: notificationLog.payload,
+            sentAt: notificationLog.sentAt,
+            title: notificationLog.title,
+        })
+        .from(notificationLog)
+        .where(
+            and(
+                eq(notificationLog.event, "health_ping_fail"),
+                gte(notificationLog.sentAt, since)
+            )
+        )
+        .orderBy(desc(notificationLog.sentAt));
+
+    return rows
+        .filter((row) => {
+            const payload = row.payload as Record<string, any> | null;
+            return payload?.id && databaseIds.includes(payload.id);
+        })
+        .map((row) => {
+            const payload = row.payload as Record<string, any>;
+            return {
+                databaseId: payload.id as string,
+                databaseName: (payload.host as string) || "",
+                timestamp: row.sentAt,
+            };
+        });
+}
+
+export async function getDatabasesWithHealth(organizationIds: string[]) {
+    if (organizationIds.length === 0) return [];
+
+    const projects = await db.query.project.findMany({
+        where: inArray(drizzleDb.schemas.project.organizationId, organizationIds),
+    });
+
+    const projectIds = projects.map((p) => p.id);
+    if (projectIds.length === 0) return [];
+
+    const databases = await db.query.database.findMany({
+        where: inArray(drizzleDb.schemas.database.projectId, projectIds),
+        with: {
+            agent: true,
+            project: true,
+        },
+    });
+
+    return databases;
+}

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -41,7 +41,7 @@ export const env = createEnv({
 
     HEALTH_PING_CRON: z
       .string()
-      .default("* * * * *"),
+      .default("*/30 * * * * *"),
 
     AUTH_OIDC_ID: z.string().optional().default("oidc"),
     AUTH_OIDC_TITLE: z.string().optional(),

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -39,6 +39,10 @@ export const env = createEnv({
         process.env.NODE_ENV === "production" ? "0 7 * * *" : "* * * * *",
       ),
 
+    HEALTH_PING_CRON: z
+      .string()
+      .default("* * * * *"),
+
     AUTH_OIDC_ID: z.string().optional().default("oidc"),
     AUTH_OIDC_TITLE: z.string().optional(),
     AUTH_OIDC_DESC: z.string().optional(),
@@ -95,6 +99,7 @@ export const env = createEnv({
     SMTP_SECURE: process.env.SMTP_SECURE,
 
     RETENTION_CRON: process.env.RETENTION_CRON,
+    HEALTH_PING_CRON: process.env.HEALTH_PING_CRON,
 
     AUTH_OIDC_ID: process.env.AUTH_OIDC_ID,
     AUTH_OIDC_TITLE: process.env.AUTH_OIDC_TITLE,

--- a/src/features/notifications/helpers.ts
+++ b/src/features/notifications/helpers.ts
@@ -7,7 +7,7 @@ export async function sendNotificationsBackupRestore(database: DatabaseWith, eve
         return [];
     }
 
-    const activePolicies = database.alertPolicies.filter(policy => 
+    const activePolicies = database.alertPolicies.filter(policy =>
         policy.enabled && policy.eventKinds.includes(event)
     );
 
@@ -33,6 +33,11 @@ export async function sendNotificationsBackupRestore(database: DatabaseWith, eve
                 level = "info";
                 message = `Weekly report generated at ${date.toISOString()}.`;
                 break;
+            case "health_ping_fail":
+                level = "critical";
+                message = `Health ping failed for database "${database.name}" at ${date.toISOString()}. No contact from agent.`;
+                error = "Database unreachable - check agent connectivity";
+                break;
         }
 
         const titleMap: Record<EventKind, string> = {
@@ -41,6 +46,7 @@ export async function sendNotificationsBackupRestore(database: DatabaseWith, eve
             success_backup: `Backup Notification`,
             success_restore: `Restore Notification`,
             weekly_report: `Weekly Report Notification`,
+            health_ping_fail: `Health Ping Notification`,
         };
 
         const payload: EventPayload = {
@@ -61,4 +67,8 @@ export async function sendNotificationsBackupRestore(database: DatabaseWith, eve
 
 
     return Promise.all(promises);
+}
+
+export async function sendHealthPingFailNotification(database: DatabaseWith) {
+    return sendNotificationsBackupRestore(database, "health_ping_fail");
 }

--- a/src/features/notifications/types.ts
+++ b/src/features/notifications/types.ts
@@ -18,4 +18,4 @@ export interface EventPayload {
     data?: Record<string, any>;
 }
 
-export type EventKind = ("error_backup" | "error_restore" | "success_restore" | "success_backup" | "weekly_report")
+export type EventKind = ("error_backup" | "error_restore" | "success_restore" | "success_backup" | "weekly_report" | "health_ping_fail")

--- a/src/lib/tasks/health/index.ts
+++ b/src/lib/tasks/health/index.ts
@@ -1,0 +1,40 @@
+import {db} from "@/db";
+import * as drizzleDb from "@/db";
+import {isNotNull, sql} from "drizzle-orm";
+import {sendHealthPingFailNotification} from "@/features/notifications/helpers";
+import {DatabaseWith} from "@/db/schema/07_database";
+
+const HEALTH_THRESHOLD_SECONDS = 60;
+
+export const healthPingTask = async () => {
+    try {
+        const databases = await db.query.database.findMany({
+            where: isNotNull(drizzleDb.schemas.database.lastContact),
+            with: {
+                alertPolicies: {
+                    with: {
+                        notificationChannel: true,
+                    },
+                },
+                agent: true,
+                project: true,
+            },
+        });
+
+        const now = Date.now();
+        const unhealthyDatabases = databases.filter((database) => {
+            if (!database.lastContact) return false;
+            const secondsSinceContact = (now - database.lastContact.getTime()) / 1000;
+            return secondsSinceContact > HEALTH_THRESHOLD_SECONDS;
+        });
+
+        console.log(`Health Ping: ${unhealthyDatabases.length} unhealthy database(s) detected out of ${databases.length} total`);
+
+        for (const database of unhealthyDatabases) {
+            await sendHealthPingFailNotification(database as DatabaseWith);
+        }
+    } catch (e: any) {
+        console.error("Health ping task failed:", e);
+        throw e;
+    }
+};

--- a/src/lib/tasks/health/index.ts
+++ b/src/lib/tasks/health/index.ts
@@ -1,8 +1,9 @@
 import {db} from "@/db";
 import * as drizzleDb from "@/db";
-import {isNotNull, sql} from "drizzle-orm";
+import {isNotNull} from "drizzle-orm";
 import {sendHealthPingFailNotification} from "@/features/notifications/helpers";
 import {DatabaseWith} from "@/db/schema/07_database";
+import {notificationLog} from "@/db/schema/11_notification-log";
 
 const HEALTH_THRESHOLD_SECONDS = 60;
 
@@ -31,6 +32,26 @@ export const healthPingTask = async () => {
         console.log(`Health Ping: ${unhealthyDatabases.length} unhealthy database(s) detected out of ${databases.length} total`);
 
         for (const database of unhealthyDatabases) {
+            // Always log the failure for chart data
+            await db.insert(notificationLog).values({
+                channelId: "00000000-0000-0000-0000-000000000000",
+                provider: "system",
+                providerName: "Health Ping Monitor",
+                event: "health_ping_fail",
+                title: "Health Ping Notification",
+                message: `Health ping failed for database "${database.name}". No contact from agent.`,
+                level: "critical",
+                payload: {
+                    host: database.name,
+                    id: database.id,
+                    agentDatabaseId: database.agentDatabaseId,
+                    error: "Database unreachable - check agent connectivity",
+                },
+                success: true,
+                error: null,
+            });
+
+            // Also dispatch to configured alert policies if any
             await sendHealthPingFailNotification(database as DatabaseWith);
         }
     } catch (e: any) {

--- a/src/lib/tasks/index.ts
+++ b/src/lib/tasks/index.ts
@@ -2,6 +2,7 @@ import cron from "node-cron";
 import {retentionCleanTask} from "@/lib/tasks/database";
 import {env} from "@/env.mjs";
 import {backupCleanTask} from "@/lib/tasks/cleaning";
+import {healthPingTask} from "@/lib/tasks/health";
 
 
 export const retentionJob = cron.schedule(env.RETENTION_CRON, async () => {
@@ -17,6 +18,15 @@ export const cleaningJob = cron.schedule("* * * * *", async () => {
     try {
         console.log("Cleaning Job : Starting task");
         await backupCleanTask();
+    } catch (err) {
+        console.error(`[CRON] Error:`, err);
+    }
+});
+
+export const healthPingJob = cron.schedule(env.HEALTH_PING_CRON, async () => {
+    try {
+        console.log("Health Ping Job : Starting task");
+        await healthPingTask();
     } catch (err) {
         console.error(`[CRON] Error:`, err);
     }

--- a/src/utils/init.ts
+++ b/src/utils/init.ts
@@ -2,7 +2,7 @@ import { env } from "@/env.mjs";
 import { db, makeMigration } from "@/db";
 import { eq } from "drizzle-orm";
 import * as drizzleDb from "@/db";
-import { cleaningJob, retentionJob } from "@/lib/tasks";
+import { cleaningJob, healthPingJob, retentionJob } from "@/lib/tasks";
 import { generateRSAKeys, getOrCreateMasterKey } from "@/utils/rsa-keys";
 import { StorageProviderKind } from "@/features/storages/types";
 
@@ -17,6 +17,7 @@ export async function init() {
   console.log("====Initialization completed====");
   await setupCronJobs();
   await setupCleaningJobs();
+  await setupHealthPingJobs();
 
   if (
     (env.AUTH_GOOGLE_ID && env.AUTH_GOOGLE_SECRET) ||
@@ -38,6 +39,12 @@ async function setupCleaningJobs() {
   console.log("==== Setting up Cleaning Jobs ====");
   cleaningJob.start();
   console.log("==== Cleaning job started ====");
+}
+
+async function setupHealthPingJobs() {
+  console.log("==== Setting up Health Ping Jobs ====");
+  healthPingJob.start();
+  console.log("==== Health Ping job started ====");
 }
 
 async function createSettingsIfNotExist() {


### PR DESCRIPTION
Add a health ping system that monitors database connectivity via lastContact timestamps and alerts users through existing notification channels when databases become unreachable. Includes a GitHub-style green/red contribution grid chart, a dedicated Health Status admin page, sidebar navigation, per-database dashboard pinning, and a new health_ping_fail alert policy event kind.

## Developer Choices I have made:

  Cron & Threshold:
  - Health check runs every 30 seconds (*/30 * * * * *) by default, configurable via HEALTH_PING_CRON
  env var
  - 60-second staleness threshold (2 missed agent pings) — hardcoded, balances false positive avoidance
   with responsiveness
  - Only databases with a non-null lastContact are monitored — databases that have never contacted the
  system are excluded

  Data & Architecture:
  - Dual logging: every failure is logged to notification_log with a system channel UUID (00000000-...)
   regardless of alert policy config, so chart data exists even without any policies set up
  - Reuses existing notification_log table filtered by event = "health_ping_fail" rather than creating
  a dedicated health tracking table
  - Dashboard pinning is per-user — each user can pin/unpin independently without affecting others

  Chart:
  - 180-day window: 90 past + 90 forecast with today ring-highlighted in the center
  - Failure severity uses 4 color levels: green (0), red-400 (1-4), red-500 (5-9), red-600 (10+)
  - Forecast cells are grey circles — visually distinct from past data circles
  - "Healthy" is an assumption for days without a failure event (no separate "success" events are
  logged)

  UI Structure:
  - Agent/Database tabs scaffold future direct DB connectivity monitoring separately from agent status
  - "Agent Health" badge on dashboard makes it clear pinned charts are agent-level, not DB-level


## Features:
### Allows Users to pin to dashboard
- Step 1: Toggle on any DB health charts you wish to render in main dashboard
<img width="1857" height="966" alt="image" src="https://github.com/user-attachments/assets/3d05b10e-f19d-465c-bf88-27173afad660" />

- Step 2: Verify the Charts render in main dashboard
<img width="1862" height="968" alt="image" src="https://github.com/user-attachments/assets/632af787-8556-45e2-bfa3-9f79b1eb0bd8" />

### Add failed health events as a option for notification
- New Event is created which can be used to trigger notifications.
<img width="1870" height="976" alt="image" src="https://github.com/user-attachments/assets/ba3253cc-6811-4c38-8e6d-9079d382f07a" />


### UI/UX Enhancements:
- Add Nav icon from individual Project section to health monitoring page. 
<img width="1866" height="977" alt="image" src="https://github.com/user-attachments/assets/38657372-665d-41a3-b5ba-0a9920694a31" />
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health monitoring dashboard and dedicated Health Status page with visualizations.
  * Pin/unpin databases to the home dashboard and view per-database health charts.
  * Health ping task that detects unreachable databases and emits failure notifications.

* **Chores**
  * Database migration and schema for storing health dashboard preferences.
  * Added configurable scheduler for health pings (env variable).

* **Notifications**
  * Health ping failure event type and notification helper added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->