### PR TITLE
fix: readme [skip-release]

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ You have 4 ways to install Portabase:
 
 | Engine             | Support   | Supported Versions                | Restore |
 |:-------------------|:----------|:----------------------------------|:--------|
-| **PostgreSQL**     | ✅ Stable  | 12, 13, 14, 15, 16, 17 et 18      | Yes     |
-| **MySQL**          | ✅ Stable  | 5.7, 8 et 9                       | Yes     |
-| **MariaDB**        | ✅ Stable  | 10 et 11                          | Yes     |
-| **MongoDB**        | ✅ Stable  | 4, 5, 6, 7 et 8                   | Yes     |
+| **PostgreSQL**     | ✅ Stable  | 12, 13, 14, 15, 16, 17 and 18      | Yes     |
+| **MySQL**          | ✅ Stable  | 5.7, 8 and 9                       | Yes     |
+| **MariaDB**        | ✅ Stable  | 10 and 11                          | Yes     |
+| **MongoDB**        | ✅ Stable  | 4, 5, 6, 7 and 8                   | Yes     |
 | **SQLite**         | ✅ Stable  | 3.x                               | Yes     |
 | **Redis**          | ✅ Stable  | 2.8+                              | No      |
 | **Valkey**         | ✅ Stable  | 7.2+                              | No      |

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ You have 4 ways to install Portabase:
 | **Redis**          | ✅ Stable  | 2.8+                              | No      |
 | **Valkey**         | ✅ Stable  | 7.2+                              | No      |
 | **MSSQL Server**   | ❌ Ongoing | -                                 | Yes     |
+| **Firebird**   | ❌ Ongoing | -                                 | Yes     |
 
 See the [Database Servers documentation](https://portabase.io/docs/agent/db) for version-specific backup and restore details.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized phrasing in the "Supported databases" table to use "and" when listing supported versions for PostgreSQL, MySQL, MariaDB, and MongoDB.
  * Added a new Firebird row (ongoing support, restore: yes) to the "Supported databases" table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->