### PR TITLE
fix: demo-banner

### DIFF
--- a/app/api/v1/mcp/route.ts
+++ b/app/api/v1/mcp/route.ts
@@ -11,8 +11,8 @@ import { env } from "@/env.mjs";
  * Auth is handled by withApiKey before MCP is ever touched.
  * The validated key is forwarded by MCP tools to downstream /api/v1 REST calls.
  */
-const apiEnabled = String(env.API_ENABLED) === "true";
-const mcpEnabled = String(env.MCP_ENABLED) === "true";
+const apiEnabled = env.API_ENABLED;
+const mcpEnabled = env.MCP_ENABLED;
 
 export const POST = apiEnabled && mcpEnabled
   ? withApiKey(async (req: Request, ctx: ApiKeyContext) => {

--- a/proxy.ts
+++ b/proxy.ts
@@ -43,7 +43,7 @@ export async function proxy(request: NextRequest) {
 
   if (url.pathname.startsWith("/api")) {
     if (url.pathname.startsWith("/api/v1")) {
-      const apiEnabled = String(env.API_ENABLED) === "true";
+      const apiEnabled = env.API_ENABLED;
       if (!apiEnabled) {
         return new NextResponse(
           JSON.stringify({
@@ -53,7 +53,7 @@ export async function proxy(request: NextRequest) {
           { status: 404, headers: { "Content-Type": "application/json" } },
         );
       }
-      const openapiEnabled = String(env.OPENAPI_ENABLED) === "true";
+      const openapiEnabled = env.OPENAPI_ENABLED;
       if (
         !openapiEnabled &&
         (url.pathname.startsWith("/api/v1/docs") ||

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -113,6 +113,11 @@ export const env = createEnv({
             .enum(["true", "false"])
             .transform((val) => val === "true")
             .default("false"),
+
+        DEMO_ENABLED: z
+            .enum(["true", "false"])
+            .transform((val) => val === "true")
+            .default("false"),
     },
     client: {
         NEXT_PUBLIC_PROJECT_VERSION: z.string().optional(),
@@ -189,6 +194,8 @@ export const env = createEnv({
         OPENAPI_ENABLED: process.env.OPENAPI_ENABLED,
         API_ENABLED: process.env.API_ENABLED,
         MCP_ENABLED: process.env.MCP_ENABLED,
+
+        DEMO_ENABLED: process.env.DEMO_ENABLED,
 
     },
 });

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -36,8 +36,8 @@ export const env = createEnv({
 
         SMTP_SECURE: z
             .enum(["true", "false"])
-            .transform((val) => val === "true")
-            .default("true"),
+            .default("true")
+            .transform((val) => val === "true"),
 
         AUTH_GOOGLE_ID: z.string().optional(),
         AUTH_GOOGLE_SECRET: z.string().optional(),
@@ -101,23 +101,23 @@ export const env = createEnv({
 
         OPENAPI_ENABLED: z
             .enum(["true", "false"])
-            .transform((val) => val === "true")
-            .default("false"),
+            .default("false")
+            .transform((val) => val === "true"),
 
         API_ENABLED: z
             .enum(["true", "false"])
-            .transform((val) => val === "true")
-            .default("false"),
+            .default("false")
+            .transform((val) => val === "true"),
 
         MCP_ENABLED: z
             .enum(["true", "false"])
-            .transform((val) => val === "true")
-            .default("false"),
+            .default("false")
+            .transform((val) => val === "true"),
 
         DEMO_ENABLED: z
             .enum(["true", "false"])
-            .transform((val) => val === "true")
-            .default("false"),
+            .default("false")
+            .transform((val) => val === "true"),
     },
     client: {
         NEXT_PUBLIC_PROJECT_VERSION: z.string().optional(),

--- a/src/features/layout/demo-reset-banner.tsx
+++ b/src/features/layout/demo-reset-banner.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { Timer } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
 
 function getSecondsUntilNextHour(): number {
     const now = new Date();
@@ -21,13 +22,15 @@ export function DemoResetBanner() {
     const [secondsLeft, setSecondsLeft] = useState<number | null>(null);
 
     useEffect(() => {
-        setSecondsLeft(getSecondsUntilNextHour());
+        const tick = () => setSecondsLeft(getSecondsUntilNextHour());
 
-        const interval = setInterval(() => {
-            setSecondsLeft(getSecondsUntilNextHour());
-        }, 1000);
+        const timeout = setTimeout(tick, 0);
+        const interval = setInterval(tick, 1000);
 
-        return () => clearInterval(interval);
+        return () => {
+            clearTimeout(timeout);
+            clearInterval(interval);
+        };
     }, []);
 
     if (secondsLeft === null) return null;
@@ -36,16 +39,16 @@ export function DemoResetBanner() {
     const isWarning = secondsLeft > 0 && secondsLeft <= 300;
 
     return (
-        <span
+        <Badge
+            variant="outline"
             className={cn(
-                'hidden md:inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium',
+                'hidden md:inline-flex h-7',
                 isResetting && 'animate-pulse border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950/30 dark:text-red-400',
                 isWarning && 'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-400',
-                !isResetting && !isWarning && 'border-input bg-background text-muted-foreground',
             )}
         >
-            <Timer className="size-3 shrink-0" aria-hidden="true" />
-            {isResetting ? 'Resetting…' : `Resets in ${formatTime(secondsLeft)}`}
-        </span>
+            <Timer aria-hidden="true" />
+            {isResetting ? 'Resetting…' : `Demo resets in ${formatTime(secondsLeft)}`}
+        </Badge>
     );
 }

--- a/src/features/layout/demo-reset-banner.tsx
+++ b/src/features/layout/demo-reset-banner.tsx
@@ -10,9 +10,10 @@ function getSecondsUntilNextHour(): number {
 }
 
 function formatTime(seconds: number): string {
-    const m = Math.floor(seconds / 60);
-    const s = seconds % 60;
-    return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+    const s = Math.max(0, seconds);
+    const m = Math.floor(s / 60);
+    const sec = s % 60;
+    return `${String(m).padStart(2, '0')}:${String(sec).padStart(2, '0')}`;
 }
 
 export function DemoResetBanner() {
@@ -22,10 +23,7 @@ export function DemoResetBanner() {
         setSecondsLeft(getSecondsUntilNextHour());
 
         const interval = setInterval(() => {
-            setSecondsLeft((prev) => {
-                if (prev === null || prev <= 0) return 0;
-                return prev - 1;
-            });
+            setSecondsLeft(getSecondsUntilNextHour());
         }, 1000);
 
         return () => clearInterval(interval);

--- a/src/features/layout/demo-reset-banner.tsx
+++ b/src/features/layout/demo-reset-banner.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Timer } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+function getSecondsUntilNextHour(): number {
+    const now = new Date();
+    return 3600 - (now.getMinutes() * 60 + now.getSeconds());
+}
+
+function formatTime(seconds: number): string {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+}
+
+export function DemoResetBanner() {
+    const [secondsLeft, setSecondsLeft] = useState<number | null>(null);
+
+    useEffect(() => {
+        setSecondsLeft(getSecondsUntilNextHour());
+
+        const interval = setInterval(() => {
+            setSecondsLeft((prev) => {
+                if (prev === null || prev <= 0) return 0;
+                return prev - 1;
+            });
+        }, 1000);
+
+        return () => clearInterval(interval);
+    }, []);
+
+    if (secondsLeft === null) return null;
+
+    const isResetting = secondsLeft === 0;
+    const isWarning = secondsLeft > 0 && secondsLeft <= 300;
+
+    return (
+        <span
+            className={cn(
+                'hidden md:inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium',
+                isResetting && 'animate-pulse border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950/30 dark:text-red-400',
+                isWarning && 'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-400',
+                !isResetting && !isWarning && 'border-input bg-background text-muted-foreground',
+            )}
+        >
+            <Timer className="size-3 shrink-0" aria-hidden="true" />
+            {isResetting ? 'Resetting…' : `Resets in ${formatTime(secondsLeft)}`}
+        </span>
+    );
+}

--- a/src/features/layout/demo-reset-banner.tsx
+++ b/src/features/layout/demo-reset-banner.tsx
@@ -6,7 +6,8 @@ import { cn } from '@/lib/utils';
 
 function getSecondsUntilNextHour(): number {
     const now = new Date();
-    return 3600 - (now.getMinutes() * 60 + now.getSeconds());
+    const s = 3600 - (now.getMinutes() * 60 + now.getSeconds());
+    return s === 3600 ? 0 : s;
 }
 
 function formatTime(seconds: number): string {

--- a/src/features/layout/header.tsx
+++ b/src/features/layout/header.tsx
@@ -5,6 +5,8 @@ import {currentUser} from "@/lib/auth/current-user";
 import {BreadCrumbsWrapper} from "@/components/common/bread-crumbs";
 import GitHubStarsButtonCustom from "@/components/common/github-button";
 import {LoggedInButton} from "@/features/layout/logged-in-button.server";
+import { env } from "@/env.mjs";
+import { DemoResetBanner } from "@/features/layout/demo-reset-banner";
 
 export const Header = async ({ actions }: { actions?: ReactNode } = {}) => {
     const user = await currentUser();
@@ -18,6 +20,7 @@ export const Header = async ({ actions }: { actions?: ReactNode } = {}) => {
                 <BreadCrumbsWrapper/>
             </div>
             <div className="flex items-center gap-2">
+                {env.DEMO_ENABLED && <DemoResetBanner />}
                 <GitHubStarsButtonCustom/>
                 {actions}
                 <LoggedInButton/>

--- a/src/features/layout/header.tsx
+++ b/src/features/layout/header.tsx
@@ -13,8 +13,7 @@ export const Header = async ({ actions }: { actions?: ReactNode } = {}) => {
     if (!user) {
         return notFound();
     }
-    const demoEnabled = String(env.DEMO_ENABLED) === "true";
-
+    const demoEnabled = env.DEMO_ENABLED;
     return (
         <header className="flex h-16 shrink-0 items-center justify-between border-b px-4">
             <div className="flex items-center justify-between">

--- a/src/features/layout/header.tsx
+++ b/src/features/layout/header.tsx
@@ -13,6 +13,8 @@ export const Header = async ({ actions }: { actions?: ReactNode } = {}) => {
     if (!user) {
         return notFound();
     }
+    const demoEnabled = String(env.DEMO_ENABLED) === "true";
+
     return (
         <header className="flex h-16 shrink-0 items-center justify-between border-b px-4">
             <div className="flex items-center justify-between">
@@ -20,7 +22,7 @@ export const Header = async ({ actions }: { actions?: ReactNode } = {}) => {
                 <BreadCrumbsWrapper/>
             </div>
             <div className="flex items-center gap-2">
-                {env.DEMO_ENABLED && <DemoResetBanner />}
+                {demoEnabled && <DemoResetBanner />}
                 <GitHubStarsButtonCustom/>
                 {actions}
                 <LoggedInButton/>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a demo reset countdown banner that appears when demo mode is enabled; shows seconds until the next hourly reset with amber warning (<5 min) and red pulsing when imminent.
  * Header now shows the demo banner only when demo mode is active.

* **Other Changes**
  * Feature flags for API/OpenAPI/MCP are handled as booleans so disabled endpoints return the expected “not available” responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->