### PR TITLE
fix: Enable --behind-proxy for tusd

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,3 +78,6 @@ TRUSTED_DOMAINS="http://localhost:8887, http://localhost:3055, http://localhost:
 #OPENAPI_ENABLED=true
 #API_ENABLED=true
 #MCP_ENABLED=true
+
+# Default to false
+#TUSD_BEHIND_PROXY=true

--- a/docker/dockerfile/Dockerfile
+++ b/docker/dockerfile/Dockerfile
@@ -92,6 +92,7 @@ ENV PORT=80
 ENV HOSTNAME="0.0.0.0"
 ENV PGDATA=/data/postgres
 ENV PRIVATE_PATH=/data/private
+ENV TUSD_BEHIND_PROXY=false
 
 
 RUN addgroup --system --gid 1001 nodejs

--- a/docker/entrypoints/app-prod-entrypoint.sh
+++ b/docker/entrypoints/app-prod-entrypoint.sh
@@ -75,6 +75,7 @@ echo "▶ Starting tusd server..."
 TUSD_BEHIND_PROXY_FLAG=""
 if [ "${TUSD_BEHIND_PROXY:-false}" = "true" ]; then
     TUSD_BEHIND_PROXY_FLAG="--behind-proxy"
+    echo "[INFO] TUSD_BEHIND_PROXY=true, enabling tusd proxy mode"
 fi
 tusd \
     --base-path /tus/files/ \

--- a/docker/entrypoints/app-prod-entrypoint.sh
+++ b/docker/entrypoints/app-prod-entrypoint.sh
@@ -72,7 +72,17 @@ fi
 
 mkdir -p /data/private/uploads/tmp
 echo "▶ Starting tusd server..."
-tusd --base-path /tus/files/ --upload-dir /data/private/uploads/tmp --hooks-http http://127.0.0.1:3000/api/tus/hooks --port 1080 --max-size 21474836480 &
+TUSD_BEHIND_PROXY_FLAG=""
+if [ "${TUSD_BEHIND_PROXY:-false}" = "true" ]; then
+    TUSD_BEHIND_PROXY_FLAG="--behind-proxy"
+fi
+tusd \
+    --base-path /tus/files/ \
+    --upload-dir /data/private/uploads/tmp \
+    --hooks-http http://127.0.0.1:3000/api/tus/hooks \
+    --port 1080 \
+    --max-size 21474836480 \
+    $TUSD_BEHIND_PROXY_FLAG &
 
 echo "▶ Starting Next.js server..."
 PORT=3000 node server.js &

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,6 +1,11 @@
 events {}
 
 http {
+    map $http_x_forwarded_proto $forwarded_proto {
+        default $scheme;
+        "~*^https?$" $http_x_forwarded_proto;
+    }
+
     client_max_body_size 20G;
     ignore_invalid_headers  off;
 
@@ -18,7 +23,7 @@ http {
 
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-Host $http_host;
-            proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
             proxy_set_header         Upgrade $http_upgrade;
@@ -34,7 +39,7 @@ http {
 
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-Host $http_host;
-            proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
     }

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -18,7 +18,7 @@ http {
 
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-Host $http_host;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
             proxy_set_header         Upgrade $http_upgrade;
@@ -34,7 +34,7 @@ http {
 
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-Host $http_host;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
     }

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -3,7 +3,7 @@ events {}
 http {
     map $http_x_forwarded_proto $forwarded_proto {
         default $scheme;
-        "~*^https?$" $http_x_forwarded_proto;
+        "~*^\s*(https?)\s*(?:,|$)" $1;
     }
 
     client_max_body_size 20G;

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -24,6 +24,8 @@ spec:
               value: {{ .Values.project.url }}
             - name: PROJECT_SECRET
               value: {{ .Values.project.secret }}
+            - name: TUSD_BEHIND_PROXY
+              value: {{ .Values.project.behindProxy | quote }}
           volumeMounts:
             - name: data
               mountPath: /data

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -23,6 +23,7 @@ timezone: Europe/Paris
 project:
   url: http://localhost:8887
   secret: "change_me_generate_secure_secret"
+  behindProxy: false
 
 persistence:
   enabled: true


### PR DESCRIPTION
## Summary

This PR fixes issues when Portabase is deployed behind a reverse proxy.

Related issue: https://github.com/Portabase/portabase/issues/279

These changes ensure that tusd correctly handles HTTPS requests and generates proper URLs when Portabase is running behind one or more reverse proxies.

## Changes

| File | Change |
|------|--------|
| `docker/dockerfile/Dockerfile` | Adds the `TUSD_BEHIND_PROXY` environment variable with a default value of `false` |
| `docker/entrypoints/app-prod-entrypoint.sh` | Refactors the tusd startup command and conditionally enables the `--behind-proxy` flag based on `TUSD_BEHIND_PROXY` |
| `docker/nginx/nginx.conf` | Forwards the original `X-Forwarded-Proto` header instead of overriding it with the local request scheme |
| `helm/templates/deployment.yaml` | Adds support for injecting the `TUSD_BEHIND_PROXY` environment variable from Helm values |
| `helm/values.yaml` | Adds the `project.behindProxy` configuration option (default: `false`) |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to enable running the app behind a proxy via an environment/Helm setting.

* **Chores**
  * Deployment and startup now honor the proxy setting.
  * Reverse-proxy configuration updated to forward original protocol headers for consistent upstream request handling.
  * Example env updated to show the new setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->