### PR TITLE
Fix: incorrect date format (DD/MM/YYYY)

### DIFF
--- a/src/components/common/day-time-picker.tsx
+++ b/src/components/common/day-time-picker.tsx
@@ -55,7 +55,7 @@ export function DateTimePicker({ name }: DateTimePickerProps) {
         <Popover>
             <PopoverTrigger asChild>
                 <Button variant="outline" className={cn("w-full pl-3 text-left font-normal", !value && "text-muted-foreground")}>
-                    {value ? format(value, "MM/dd/yyyy hh:mm aa") : <span>MM/DD/YYYY hh:mm aa</span>}
+                    {value ? format(value, "dd/MM/yyyy hh:mm aa") : <span>DD/MM/YYYY hh:mm aa</span>}
                     <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
                 </Button>
             </PopoverTrigger>

--- a/src/features/database/components/health-grid.tsx
+++ b/src/features/database/components/health-grid.tsx
@@ -92,7 +92,7 @@ function getOldestLog(logs: HealthcheckLog[]): HealthcheckLog {
 }
 
 function formatTime(date: Date): string {
-    return date.toLocaleTimeString("en-US", {
+    return date.toLocaleTimeString("en-GB", {
         hour: "2-digit",
         minute: "2-digit",
         hour12: false,

--- a/src/features/organizations/components/organization-member-card.tsx
+++ b/src/features/organizations/components/organization-member-card.tsx
@@ -57,7 +57,7 @@ export const OrganizationMemberCard = ({member, organization}: OrganizationMembe
                     <div className="font-medium">{member.user.name}</div>
                     <div className="text-sm text-muted-foreground">{member.user.email}</div>
                     <div
-                        className="text-xs text-muted-foreground">Joined {formatDayOnly(new Date(member.createdAt))}</div>
+                        className="text-xs text-muted-foreground">Joined {formatDayOnly(member.createdAt)}</div>
                 </div>
             </div>
             <div className="flex items-center space-x-2 mt-4 md:mt-0">

--- a/src/features/organizations/components/organization-member-card.tsx
+++ b/src/features/organizations/components/organization-member-card.tsx
@@ -19,6 +19,7 @@ import {
     OrganizationMemberChangeRoleModal
 } from "@/features/organizations/components/organization-member-change-role";
 import {MemberWithUser, OrganizationWithMembersAndUsers} from "@/db/schema/03_organization";
+import {formatDayOnly} from "@/utils/date-formatting";
 
 type OrganizationMemberCardProps = {
     member: MemberWithUser;
@@ -56,7 +57,7 @@ export const OrganizationMemberCard = ({member, organization}: OrganizationMembe
                     <div className="font-medium">{member.user.name}</div>
                     <div className="text-sm text-muted-foreground">{member.user.email}</div>
                     <div
-                        className="text-xs text-muted-foreground">Joined {new Date(member.createdAt).toLocaleDateString()}</div>
+                        className="text-xs text-muted-foreground">Joined {formatDayOnly(new Date(member.createdAt))}</div>
                 </div>
             </div>
             <div className="flex items-center space-x-2 mt-4 md:mt-0">

--- a/src/features/profile/components/profile-security.tsx
+++ b/src/features/profile/components/profile-security.tsx
@@ -44,7 +44,6 @@ import { Account, Session, User } from "@/db/schema/02_user";
 import { Icon } from "@iconify/react";
 import Image from "next/image";
 import type { AuthProviderConfig } from "@/lib/auth/config";
-import { is } from "date-fns/locale";
 
 interface ProfileSecurityProps {
   user: User;

--- a/src/features/projects/components/bulk-restore-modal.tsx
+++ b/src/features/projects/components/bulk-restore-modal.tsx
@@ -6,6 +6,7 @@ import {Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter} from "@/
 import {Button} from "@/components/ui/button";
 import {Input} from "@/components/ui/input";
 import type {RestorePreviewRow} from "@/features/database/actions/bulk-restore.action";
+import {formatLocalizedDate} from "@/utils/date-formatting";
 
 const CONFIRM_WORD = "restore";
 
@@ -54,7 +55,7 @@ export const BulkRestoreModal = (props: BulkRestoreModalProps) => {
                                         <td className={`p-2 ${r.restorable ? "" : "opacity-50"}`}>{r.name}</td>
                                         <td className="p-2">
                                             {r.restorable
-                                                ? <span className="text-green-600">{r.backupDate ? new Date(r.backupDate).toLocaleString() : "latest backup"}</span>
+                                                ? <span className="text-green-600">{r.backupDate ? formatLocalizedDate(r.backupDate) : "latest backup"}</span>
                                                 : <span className="text-amber-500">{r.reason ?? "no successful backup"} — skipped</span>}
                                         </td>
                                     </tr>

--- a/src/utils/date-formatting.ts
+++ b/src/utils/date-formatting.ts
@@ -38,13 +38,14 @@ export function formatDateLastContact(lastContact: string | number | Date | null
         : "Never connected.";
 }
 
-export function formatDayOnly(date: Date) {
+export function formatDayOnly(date: string | number | Date) {
+    const d = new Date(date);
     return new Intl.DateTimeFormat("en-GB", {
         day: "2-digit",
         month: "2-digit",
         year: "numeric",
         timeZone: TIMEZONE,
-    }).format(date);
+    }).format(d);
 }
 
 export function getTodayISODate() {

--- a/src/utils/date-formatting.ts
+++ b/src/utils/date-formatting.ts
@@ -1,23 +1,24 @@
 import {formatDistanceToNow} from "date-fns";
 
 /**
- * Get user's locale and timezone from the browser
+ * Detect the user's timezone from the browser (or server during SSR fallback).
  */
 const TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
-const LOCALE = Intl.DateTimeFormat().resolvedOptions().locale;
 
 /**
- * Format a date in DD/MM/YYYY HH:mm 24-hour format
+ * Format a date to DD/MM/YYYY HH:mm in 24-hour format using the en-GB locale.
+ * en-GB natively orders day before month, which matches the desired DD/MM/YYYY layout
+ * regardless of the runtime environment (SSR vs client).
  */
 export function formatLocalizedDate(date: string | number | Date) {
     const d = new Date(date);
-    return new Intl.DateTimeFormat(LOCALE, {
+    return new Intl.DateTimeFormat("en-GB", {
         day: "2-digit",
         month: "2-digit",
         year: "numeric",
         hour: "2-digit",
         minute: "2-digit",
-        hour12: false, // 24-hour format
+        hour12: false,
         timeZone: TIMEZONE,
     }).format(d);
 }
@@ -38,7 +39,7 @@ export function formatDateLastContact(lastContact: string | number | Date | null
 }
 
 export function formatDayOnly(date: Date) {
-    return new Intl.DateTimeFormat(LOCALE, {
+    return new Intl.DateTimeFormat("en-GB", {
         day: "2-digit",
         month: "2-digit",
         year: "numeric",


### PR DESCRIPTION
Fixes #289

### What was happening?

Dates were showing up as **MM/DD/YYYY** in some parts of the UI instead of the expected **DD/MM/YYYY** format.

The main reason was that shared date formatting utility was detecting the locale during module initialization using:

```ts
Intl.DateTimeFormat().resolvedOptions().locale
```

When this ran during SSR, Node.js used the server's default locale (usually `en-US`), so dates were formatted as `MM/DD/YYYY`.

A few other components were also formatting dates on their own instead of using the shared utility, which led to inconsistent behavior across the app.

### What changed?

- Updated the shared date formatting utility to always use the `en-GB` locale so dates are consistently displayed as `DD/MM/YYYY`.
- Replaced a few direct `toLocaleDateString()` / `toLocaleString()` calls with the shared formatter.
- Updated remaining hardcoded `en-US` and `MM/dd/yyyy` formats to their `DD/MM/YYYY` equivalents.
- Removed an unused `date-fns/locale` import.

### Files updated

- src/features/organizations/components/organization-member-card.tsx
- src/features/projects/components/bulk-restore-modal.tsx
- src/features/database/components/health-grid.tsx
- src/features/profile/components/profile-security.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Standardized date and time displays to **DD/MM/YYYY** with consistent **hour formatting** across key screens, including the date-time picker trigger and placeholder.
  * Improved consistency in health interval time labels/tooltips, organization member “Joined” dates, and bulk restore backup date formatting (timezone-aware).
* **Maintenance**
  * Updated shared date formatting helpers for consistent locale handling and broader input support.
  * Removed an unused import with no user-visible behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->