### PR TITLE
fix: treemap title truncate

### DIFF
--- a/src/features/stats/components/database-volume/database-treemap.tsx
+++ b/src/features/stats/components/database-volume/database-treemap.tsx
@@ -73,26 +73,22 @@ function TreemapContent(props: {
   return (
     <g>
       <rect x={x} y={y} width={width} height={height} fill={fill} rx={4} />
-      <text
-        x={x + width / 2}
-        y={y + height / 2 - 6}
-        textAnchor="middle"
-        fill="#fff"
-        fontSize={12}
-        fontWeight={600}
+      <foreignObject
+        x={x + 4}
+        y={y + height / 2 - 16}
+        width={Math.max(width - 8, 0)}
+        height={32}
+        style={{ pointerEvents: "none" }}
       >
-        {name}
-      </text>
-      <text
-        x={x + width / 2}
-        y={y + height / 2 + 10}
-        textAnchor="middle"
-        fill="#fff"
-        fontSize={10}
-        opacity={0.85}
-      >
-        {formatBytes(bytes)}
-      </text>
+        <div className="flex h-full flex-col items-center justify-center text-white">
+          <span className="w-full truncate text-center text-xs font-semibold">
+            {name}
+          </span>
+          <span className="w-full truncate text-center text-[10px] opacity-85">
+            {formatBytes(bytes)}
+          </span>
+        </div>
+      </foreignObject>
     </g>
   );
 }

--- a/src/features/stats/components/storage-volume/storage-treemap.tsx
+++ b/src/features/stats/components/storage-volume/storage-treemap.tsx
@@ -92,26 +92,22 @@ function TreemapContent(props: {
   return (
     <g>
       <rect x={x} y={y} width={width} height={height} fill={fill} rx={4} />
-      <text
-        x={x + width / 2}
-        y={y + height / 2 - 6}
-        textAnchor="middle"
-        fill="#fff"
-        fontSize={12}
-        fontWeight={600}
+      <foreignObject
+        x={x + 4}
+        y={y + height / 2 - 16}
+        width={Math.max(width - 8, 0)}
+        height={32}
+        style={{ pointerEvents: "none" }}
       >
-        {name}
-      </text>
-      <text
-        x={x + width / 2}
-        y={y + height / 2 + 10}
-        textAnchor="middle"
-        fill="#fff"
-        fontSize={10}
-        opacity={0.85}
-      >
-        {formatBytes(bytes)}
-      </text>
+        <div className="flex h-full flex-col items-center justify-center text-white">
+          <span className="w-full truncate text-center text-xs font-semibold">
+            {name}
+          </span>
+          <span className="w-full truncate text-center text-[10px] opacity-85">
+            {formatBytes(bytes)}
+          </span>
+        </div>
+      </foreignObject>
     </g>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved treemap labels for database and storage volumes with centered, truncated text.
  * Labels now display names and formatted sizes more consistently within larger tiles.
  * Prevented label overlays from interfering with treemap interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->