### PR TITLE
fix: hourly retention backups warning message about default RETENTION_CRON

### DIFF
--- a/src/features/database/components/retention-policy-form.tsx
+++ b/src/features/database/components/retention-policy-form.tsx
@@ -257,6 +257,24 @@ export const BackupRetentionSettingsForm = ({
                               field.value
                             } ${unit}${field.value === 1 ? "" : "s"}`
                           : `Disabled - no ${label.toLowerCase()} tier retained`}
+                        {key === "hourly" && (field.value ?? 0) > 0 && (
+                          <span className="mt-1 block text-amber-600 dark:text-amber-500">
+                            The default{" "}
+                            <code className="font-mono">RETENTION_CRON</code>{" "}
+                            runs once per day, so an hourly tier will not be
+                            applied unless you override it to run at least
+                            hourly (see the{" "}
+                            <a
+                              href="https://portabase.io/docs/dashboard/installation/environment"
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="underline underline-offset-2"
+                            >
+                              environment variables docs
+                            </a>
+                            ).
+                          </span>
+                        )}
                       </FormDescription>
                       <FormMessage />
                     </FormItem>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a warning beneath the hourly GFS retention setting when hourly retention is enabled.
  * Included guidance about the default daily retention schedule and a link to environment-variable documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->