### PR TITLE
fix: documentation link for decrypt backups

### DIFF
--- a/src/features/settings/components/storage-section.tsx
+++ b/src/features/settings/components/storage-section.tsx
@@ -167,6 +167,18 @@ export const SettingsStorageSection = ({settings, storageChannels}: SettingsStor
                         Master Key
                     </button>
                     </span>
+                    <span className="text-sm text-muted-foreground">
+                        Learn how to decrypt your backups in the{" "}
+                        <a
+                            href="https://portabase.io/docs/cli#backup-decryption-decrypt"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="underline underline-offset-4 hover:text-foreground transition-colors"
+                        >
+                            documentation
+                        </a>
+                        .
+                    </span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an explanatory note beneath the master-key download control.
  * Included a link to backup decryption documentation, opening securely in a new tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->